### PR TITLE
Use RedirectView CBV as default django is now 1.5

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/urls.py
+++ b/{{cookiecutter.project_name}}/django/website/urls.py
@@ -18,6 +18,6 @@ urlpatterns = patterns('',
     # This requires that static files are served from the 'static' folder.
     # The apache conf is set up to do this for you, but you will need to do it
     # on dev
-    (r'/favicon.ico', 'django.views.generic.simple.redirect_to',
+    (r'/favicon.ico', 'django.views.generic.base.RedirectView',
         {'url':  '{0}images/favicon.ico'.format(settings.STATIC_URL)}),
 )


### PR DESCRIPTION
The simple.redirect_view is not available in django 1.5. Upgrading to latest
class-based view as cookie cutter now uses django 1.5
