### PR TITLE
Import sys into local settings

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
@@ -1,4 +1,5 @@
 import private_settings
+import sys
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
Previously deploy:dev was failing out-of-the-box because of L38 checking
for 'test' in sys.argv, adding import sys to localsettings
