### PR TITLE
correct invalid json

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,5 @@
     "author_name": "Your Name",
     "email": "Your email",
     "description": "A short description of the project.",
-    "year": "Current year",
+    "year": "Current year"
 }


### PR DESCRIPTION
It's not valid json to have a comma before the closing bracket. Cookiecutter
won't run without removing this trailing comma.
