### PR TITLE
Truncate database username to 16 characters

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
@@ -8,7 +8,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': '{{ cookiecutter.project_name }}',                      # Or path to database file if using sqlite3.
-        'USER': '{{ cookiecutter.project_name }}',                      # Not used with sqlite3.
+        'USER': '{{ cookiecutter.project_name|truncate(16, True, "") }}',                      # Not used with sqlite3.
         'PASSWORD': private_settings.DB_PASSWORD,                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.dev_server
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.dev_server
@@ -7,7 +7,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': '{{ cookiecutter.project_name }}',                      # Or path to database file if using sqlite3.
-        'USER': '{{ cookiecutter.project_name }}',                      # Not used with sqlite3.
+        'USER': '{{ cookiecutter.project_name|truncate(16, True, "") }}',                      # Not used with sqlite3.
         'PASSWORD': private_settings.DB_PASSWORD,                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.production
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.production
@@ -7,7 +7,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': '{{ cookiecutter.project_name }}',                      # Or path to database file if using sqlite3.
-        'USER': '{{ cookiecutter.project_name }}',                      # Not used with sqlite3.
+        'USER': '{{ cookiecutter.project_name|truncate(16, True, "") }}',                      # Not used with sqlite3.
         'PASSWORD': private_settings.DB_PASSWORD,                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
@@ -7,7 +7,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': '{{ cookiecutter.project_name }}',                      # Or path to database file if using sqlite3.
-        'USER': '{{ cookiecutter.project_name }}',                      # Not used with sqlite3.
+        'USER': '{{ cookiecutter.project_name|truncate(16, True, "") }}',                      # Not used with sqlite3.
         'PASSWORD': private_settings.DB_PASSWORD,                  # Not used with sqlite3.
         'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.


### PR DESCRIPTION
MySQL doesn't allow usernames longer than 16 characters. But project names may be longer, so using jinja built-in truncate filter. Tested manually. Don't know how to write an automated test.
