### PR TITLE
Fix variables missing cookiecutter. prefix

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -25,16 +25,16 @@ SECRET_KEY = private_settings.SECRET_KEY
 # These email addresses will get all the error email for the production server
 # (and any other servers with DEBUG = False )
 ADMINS = (
-    ('Aptivate {{project_name}} team', '{{project_name}}-team@aptivate.org'),
-    ('{{author_name}}', '{{email}}'),  # this is in case the above email doesn't work
+    ('Aptivate {{ cookiecutter.project_name }} team', '{{ cookiecutter.project_name }}-team@aptivate.org'),
+    ('{{ cookiecutter.author_name }}', '{{ cookiecutter.email }}'),  # this is in case the above email doesn't work
 )
 
 MANAGERS = ADMINS
 
 # these are the settings for production. We can override in the various
 # local_settings if we want to
-DEFAULT_FROM_EMAIL = 'donotreply@{{ domain_name }}'
-SERVER_EMAIL = 'server@{{ domain_name }}'
+DEFAULT_FROM_EMAIL = 'donotreply@{{ cookiecutter.domain_name }}'
+SERVER_EMAIL = 'server@{{ cookiecutter.domain_name }}'
 ########## MANAGER/EMAIL CONFIGURATION
 
 

--- a/{{cookiecutter.project_name}}/wsgi/wsgi_handler.py
+++ b/{{cookiecutter.project_name}}/wsgi/wsgi_handler.py
@@ -1,5 +1,5 @@
 """
-WSGI config for {{ project_name }} project.
+WSGI config for {{ cookiecutter.project_name }} project.
 
 This module contains the WSGI application used by Django's development server
 and any production WSGI deployments. It should expose a module-level variable


### PR DESCRIPTION
Some of the templates were, for example, just {{project_name}} rather than
{{cookiecutter.project_name}}
