### PR TITLE
Use up-to-date django-extensions

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -41,6 +41,6 @@ mock==1.0.1
 
 {% if cookiecutter.django_type == 'cms' or cookiecutter.django_type == 'normal' %}
 # development
-django-extensions==1.0.2
+django-extensions
 django-debug-toolbar
 {% endif %}


### PR DESCRIPTION
v1.0.2 was using a deprecated django function which has been resolved in later
fixes. Putting to be latest version as is a development tool only.

See #34
