### PR TITLE
Install latest version of Pillow (python-imaging)

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -8,7 +8,7 @@ MySQL-python>=1.2.3
 south==0.8.4
 {% if cookiecutter.django_type == 'cms' or cookiecutter.django_type == 'normal' %}
 easy-thumbnails==1.4
-pillow==2.2.1
+pillow==2.3.1
 image_diet==0.7.1
 {% endif %}
 


### PR DESCRIPTION
I was hitting this issue when running bootstrap.py;

https://github.com/python-imaging/Pillow/issues/435

Using the latest Pillow version resolves it for me.
