### PR TITLE
Reversion 1.8.0 doesn't work with django-CMS 2.x

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -21,6 +21,8 @@ cmsplugin-blog==1.1.1
 -e git+git://github.com/salvaorenick/django-cms-redirects.git@95584ff87a669631bc4475a8482714af2505db7f#egg=django-cms-redirects
 -e git+https://github.com/daniell/djangocms-text-ckeditor.git#egg=django-text-ckeditor
 {% endif %}
+# reversion 1.8.0 doesn't work with django-CMS 2.x, and 1.7.x isn't on PyPI
+git+https://github.com/etianen/django-reversion.git@1ef455ab82576a0a45db2383b4bbc92257b50e71#egg=django-reversion
 
 {% if cookiecutter.django_type == 'cms' or cookiecutter.django_type == 'normal' %}
 # search


### PR DESCRIPTION
1.7.x isn't on PyPI so we have to check it out from github
