### PR TITLE
Load ckeditor after Django CMS

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -125,7 +125,6 @@ THIRD_PARTY_APPS = (
     'haystack',
     #{% endif %}
     #{% if cookiecutter.django_type == "cms" %}
-    'djangocms_text_ckeditor',
     'cms',
     'mptt',
     'menus',
@@ -140,6 +139,7 @@ THIRD_PARTY_APPS = (
     'cmsplugin_filer_teaser',
     'cmsplugin_filer_video',
     'cms_redirects',
+    'djangocms_text_ckeditor',  # must load after Django CMS
     #{% endif %}
 )
 


### PR DESCRIPTION
CK editor has an old template that is not compatable with current Django
versions. Django CMS already has a fix for this issue, but this requires the
CMS template to take precedence so CMS must be loaded first.
