### PR TITLE
Run migrate with --no-initial-data to create tables first.

### DIFF
--- a/dye/tasklib/django.py
+++ b/dye/tasklib/django.py
@@ -167,11 +167,12 @@ def update_db(syncdb=True, drop_test_db=True, force_use_migrations=True, databas
         cache_table = _get_cache_table()
         if cache_table and not env['db'].test_db_table_exists(cache_table):
             _manage_py(['createcachetable', cache_table])
-        _manage_py(['syncdb', '--noinput'])
+        _manage_py(['syncdb', '--noinput', '--no-initial-data'])
         # always call migrate - shouldn't fail (I think)
         # first without initial data:
         _manage_py(['migrate', '--noinput', '--no-initial-data'])
         # then with initial data, AFTER tables have been created:
+        _manage_py(['syncdb', '--noinput'])
         _manage_py(['migrate', '--noinput'])
 
 


### PR DESCRIPTION
Otherwise apps could try to load initial_data from other apps whose
tables haven't been created yet, and fail.
