### PR TITLE
Fix error "'thumbnail' tag received a bad argument: 'subject_location'"

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -285,6 +285,19 @@ LOGGING = {
 #MONKEY_PATCHES = ['intranet_binder.monkeypatches']
 ########## END BINDER STUFF
 
+
+#{% if cookiecutter.django_type == "cms" %}
+# https://django-filer.readthedocs.org/en/0.8.3/getting_started.html#configuration
+THUMBNAIL_PROCESSORS = (
+    'easy_thumbnails.processors.colorspace',
+    'easy_thumbnails.processors.autocrop',
+    #'easy_thumbnails.processors.scale_and_crop',
+    'filer.thumbnail_processors.scale_and_crop_with_subject_location',
+    'easy_thumbnails.processors.filters',
+)
+#{% endif %}
+
+
 # this section allows us to do a deep update of dictionaries
 import collections
 from copy import deepcopy


### PR DESCRIPTION
This happened when I inserted an image into a CMS page:
https://github.com/stefanfoulis/cmsplugin-filer/issues/36

Apparently the configuration of django-filer wasn't completed and needs to be.
The changes made by this patch should fix it in new projects.
