### PR TITLE
Add console logging by default.

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -264,13 +264,22 @@ LOGGING = {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            # 'formatter': 'simple'
+        },
     },
     'loggers': {
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,
+        },
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
         },
     }
 }


### PR DESCRIPTION
Most logging goes nowhere by default, which is annoying. And I've set up
console logging too many times.
