### PR TITLE
Add a default pytest configuration file.

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/pytest.ini
+++ b/{{cookiecutter.project_name}}/django/website/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = --reuse-db --strict --tb=short
+python_files=*tests.py
+
+markers = 
+    client: marks tests that use the django client (and hence run a bit slow)
+    integration: marks tests that are integration tests (just for noting)


### PR DESCRIPTION
This allows pytest to actually find our tests according to our conventions,
either using app/tests.py or app/tests/*_tests.py.
