### PR TITLE
Updates to make DYE work with Django-CMS 3.

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -2,7 +2,7 @@
 -e git+git://github.com/aptivate/dye.git#egg=dye
 
 # core django
-Django==1.5.5
+Django<1.7
 pytz==2013.9
 MySQL-python>=1.2.3
 south==0.8.4
@@ -14,14 +14,18 @@ image_diet==0.7.1
 
 {% if cookiecutter.django_type == 'cms' %}
 # django cms bits
-django-cms==2.4.3
+django-cms<3.1
 django-filer==0.9.5
 cmsplugin-filer==0.9.5
 cmsplugin-blog==1.1.1
+djangocms-link==1.3.5
+djangocms-snippet==1.0.2
+cmsplugin-googlemap==0.1.5
 -e git+git://github.com/salvaorenick/django-cms-redirects.git@95584ff87a669631bc4475a8482714af2505db7f#egg=django-cms-redirects
--e git+https://github.com/daniell/djangocms-text-ckeditor.git#egg=django-text-ckeditor
+djangocms-text-ckeditor==2.1.6
 # reversion 1.8.0 doesn't work with django-CMS 2.x, and 1.7.x isn't on PyPI
-git+https://github.com/etianen/django-reversion.git@1ef455ab82576a0a45db2383b4bbc92257b50e71#egg=django-reversion
+django-reversion<1.9
+djangocms-admin-style==0.2.2
 {% endif %}
 
 {% if cookiecutter.django_type == 'cms' or cookiecutter.django_type == 'normal' %}

--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -143,15 +143,16 @@ THIRD_PARTY_APPS = (
     'menus',
     'sekizai',
     'filer',
-    'cms.plugins.link',
-    'cms.plugins.snippet',
-    'cms.plugins.googlemap',
+    'djangocms_admin_style',
+    'djangocms_link',
+    'djangocms_snippet',
+    'cmsplugin_googlemap',
     'cmsplugin_filer_file',
     'cmsplugin_filer_folder',
     'cmsplugin_filer_image',
     'cmsplugin_filer_teaser',
     'cmsplugin_filer_video',
-    'cms_redirects',
+    'cms_redirects', # is this built into Django-CMS 3?
     'reversion',
     'djangocms_text_ckeditor',  # must load after Django CMS
     #{% endif %}


### PR DESCRIPTION
Note that:
- some CMS plugins have changed names, so we need some conditional code in
  cookiecutter if we want to support Django-CMS 2 going forward.
- not all plugins tested yet.
- cms_redirects may be superceded by built-in functionality now.
- going back to official releases of ckeditor may undo bug fixes in our fork.
