### PR TITLE
Disable DEBUG on staging servers.

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
@@ -1,6 +1,6 @@
 import private_settings
 
-DEBUG = True
+DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 ASSETS_DEBUG = DEBUG
 ASSETS_AUTO_BUILD = DEBUG


### PR DESCRIPTION
They should match the configuration of production servers, to help catch
bugs before going into production.
