### PR TITLE
Use the default EMAIL_BACKEND not celery

### DIFF
--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.dev
@@ -51,8 +51,8 @@ if 'test' in sys.argv:
     )
 
 
-CELERY_EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
-#EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+#CELERY_EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+#EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # vi: ft=python

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.dev_server
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.dev_server
@@ -36,7 +36,7 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_HOST = 'localhost'
 
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+# EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
 
 
 # vi: ft=python

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.jenkins
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.jenkins
@@ -38,7 +38,7 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_HOST = 'localhost'
 
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+# EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
 
 from settings import INSTALLED_APPS
 # add the jenkins app here

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.production
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.production
@@ -35,6 +35,6 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_HOST = 'localhost'
 
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+# EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
 
 # vi: ft=python

--- a/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
+++ b/{{cookiecutter.project_name}}/django/website/local_settings.py.staging
@@ -36,6 +36,6 @@ HAYSTACK_CONNECTIONS = {
 
 EMAIL_HOST = 'localhost'
 
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+# EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
 
 # vi: ft=python


### PR DESCRIPTION
Celery isn't installed by default so the site is broken with the current
starting configuration (so we should either include django celery in the default packages or not require it).

I've gone for the not requiring it route as it's not clear if we always want to start with Celery as the email backend (a simple site may not need it).
