### PR TITLE
add cleanup_sessions tasks

### DIFF
--- a/dye/fablib.py
+++ b/dye/fablib.py
@@ -788,6 +788,10 @@ def collect_static_files():
     _tasks('collect_static')
 
 
+def cleanup_sessions():
+    """ run django session cleanup """
+    _tasks("cleanup_sessions")
+
 def clean_db(revision=None):
     """ delete the entire database """
     if env.environment == 'production':

--- a/dye/tasklib/django.py
+++ b/dye/tasklib/django.py
@@ -289,6 +289,15 @@ def create_private_settings():
         # despite having been created by root
         #os.chmod(private_settings_file, 0400)
 
+def cleanup_sessions():
+    """ run session cleanup commands on Django 1.3+ """
+    django_version = _get_django_version()
+
+    if django_version[0] >= 1:
+        if django_version[1] >= 5:
+            _manage_py(['clearsessions'])
+        elif django_version[1] >= 3:
+            _manage_py(['cleanup'])
 
 def collect_static():
     print '### Collecting static files and building webassets'


### PR DESCRIPTION
Available from tasks.py and fab.py. Refit, for instance, will use
these as helper method during server migration.

No cron functionality added as we are delegating periodic cleanup to
puppet for the time being.

supports django 1.3+

references #57
