### PR TITLE
Fix errors when no assets are defined.

### DIFF
--- a/dye/tasklib/django.py
+++ b/dye/tasklib/django.py
@@ -311,8 +311,8 @@ def collect_static():
     sys.path.append(env['django_settings_dir'])
     import settings
     if 'django_assets' in settings.INSTALLED_APPS:
-        _manage_py(['assets', 'clean'])
-        _manage_py(['assets', 'build'])
+        _manage_py(['assets', 'clean', '--no-assets-ok'])
+        _manage_py(['assets', 'build', '--no-assets-ok'])
 
 
 def _install_django_jenkins():

--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -53,10 +53,11 @@ django-debug-toolbar
 
 # CSS and assets
 
-# Until https://github.com/miracle2k/django-assets/pull/30 is fixed,
-# we need to use our fork of django-assets for tests to pass:
+# Until https://github.com/miracle2k/django-assets/pull/30 is fixed, we need
+# to use our fork of django-assets for tests to pass, and to add the
+# --no-assets-ok option to prevent command-line build failures with no assets.
 # django-assets==0.8
--e git+https://github.com/aptivate/django-assets.git@20dc2650e3e2f2038d917c98c034d2b01b8f1dad#egg=django-assets
+-e git+https://github.com/aptivate/django-assets.git@054be6742b997fa2fe13e74fed337b3f52b07d93#egg=django-assets
 # Need to use webassets >= 0.9. https://github.com/miracle2k/django-assets/pull/31
 webassets==0.9
 pyScss==1.2.0.post3


### PR DESCRIPTION
Otherwise if you don't have any assets defined, the `collect_static` command aborts with an error, unfortunately.
