### PR TITLE
Tweak the mysqld-ram script to fix MySQL "Row size too large" errors.

### DIFF
--- a/{{cookiecutter.project_name}}/scripts/mysqld-ram.sh
+++ b/{{cookiecutter.project_name}}/scripts/mysqld-ram.sh
@@ -24,7 +24,7 @@ BIND_HOST=127.0.0.1
 BIND_PORT=3307
 
 
-DATA_DIR=/dev/shm
+DATA_DIR=/dev/shm/mysqld-ram
 PID_FILE=/var/run/mysqld/mysqld-ram.pid
 USER=mysql
 GROUP=mysql


### PR DESCRIPTION
While restoring a ruforum database dump from the staging server into a ramdisk, I got this error:

```
ERROR 1118 (42000) at line 1185: Row size too large (> 8126). Changing some columns to TEXT or BLOB or using ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED may help. In current row format, BLOB prefix of 768 bytes is stored inline.
```

The changes described in the Stack Overflow post made it work for me:

http://stackoverflow.com/questions/15585602/change-limit-for-mysql-row-size-too-large/15585700#15585700
