### PR TITLE
Remove the use of the --no-assets-ok option again.

### DIFF
--- a/dye/tasklib/django.py
+++ b/dye/tasklib/django.py
@@ -313,8 +313,8 @@ def collect_static():
     sys.path.append(env['django_settings_dir'])
     import settings
     if 'django_assets' in settings.INSTALLED_APPS:
-        _manage_py(['assets', 'clean', '--no-assets-ok'])
-        _manage_py(['assets', 'build', '--no-assets-ok'])
+        _manage_py(['assets', 'clean'])
+        _manage_py(['assets', 'build'])
 
 
 def _install_django_jenkins():

--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -54,10 +54,10 @@ django-debug-toolbar
 # CSS and assets
 
 # Until https://github.com/miracle2k/django-assets/pull/30 is fixed, we need
-# to use our fork of django-assets for tests to pass, and to add the
-# --no-assets-ok option to prevent command-line build failures with no assets.
+# to use our fork of django-assets for tests to pass, and to fix command-line
+# build failures with no assets defined.
 # django-assets==0.8
--e git+https://github.com/aptivate/django-assets.git@054be6742b997fa2fe13e74fed337b3f52b07d93#egg=django-assets
+-e git+https://github.com/aptivate/django-assets.git@775e5bb619a44a29703f7c09eaf91b780e35e8cf#egg=django-assets
 # Need to use webassets >= 0.9. https://github.com/miracle2k/django-assets/pull/31
 webassets==0.9
 pyScss==1.2.0.post3


### PR DESCRIPTION
It's been replaced upstream by simply making it not an error to have no
assets. See discussion on https://github.com/miracle2k/django-assets/pull/46
