### PR TITLE
Add linecache2 to prevent syntax error build fail

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -1,6 +1,8 @@
 # for deploy - you probably should pin to a commit
 -e git+git://github.com/aptivate/dye.git#egg=dye
 
+linecache2==1.0.0
+
 # core django
 Django<1.7
 pytz==2014.10


### PR DESCRIPTION
Add linecache2 to required packages since bootstrap will otherwise fail on Python2 installations because of syntax error in linecache's tests (Python3 syntax).