### PR TITLE
Fix bugs for the latest version of cookiecutter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
     "project_name": "project_name",
+    "repo_name": "repo_name",
     "domain_name": "Domain name",
     "author_name": "Your Name",
     "email": "Your email",

--- a/{{cookiecutter.project_name}}/django/website/settings.py
+++ b/{{cookiecutter.project_name}}/django/website/settings.py
@@ -1,4 +1,4 @@
-# Django settings for {{project_name}} project.
+# Django settings for {{ cookiecutter.project_name }} project.
 
 # Build paths inside the project like this: path.join(BASE_DIR, ...)
 from __future__ import unicode_literals, absolute_import


### PR DESCRIPTION
The latest version of cookie cutter requires a 'repo_name' variable in the config, and needs all config variables to be referenced as '{{ cookiecutter.variable_name }}'. This produced errors which are fixed by this pull request.