### PR TITLE
Use HTTPS not SSH

### DIFF
--- a/{{cookiecutter.project_name}}/deploy/pip_packages.txt
+++ b/{{cookiecutter.project_name}}/deploy/pip_packages.txt
@@ -1,5 +1,5 @@
 # for deploy - you probably should pin to a commit
--e git+ssh://git@github.com/aptivate/dye.git#egg=dye
+-e git+https://github.com/aptivate/dye.git#egg=dye
 
 linecache2==1.0.0
 


### PR DESCRIPTION
I was seeing an SSH host key error when cloning on Gitlab CI.

Moving to HTTPS was the solution.